### PR TITLE
新添上海外国语大学的网络与新媒体专业

### DIFF
--- a/list.tsv
+++ b/list.tsv
@@ -1,2 +1,3 @@
 专业	地区	学校	所在学院	贡献者学号	URL
 网络与新媒体	广东省	中山大学南方学院	文学与传媒学院	999999999	http://wcy.nfu.edu.cn/a/xueyuangaikuang/zhuanyeshezhi/wangluoyuxinmeitix/
+网络与新媒体	上海市	上海外国语大学	新闻传播学院	161042150	http://admissions.shisu.edu.cn/0f/16/c643a3862/page.htm


### PR DESCRIPTION
- 学校：上海外国语
- 网新专业所属：新闻传播学院
### 已检查tsv格式，确保正确，希望老师采纳

